### PR TITLE
Add return for res.status(400) to prevent crashing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ app.get('/info', (req, res) => {
 
 app.post('/subscribe', (req, res) => {
   if (!req.body || typeof req.body !== 'object') {
-    res.status(400).send({
+    return res.status(400).send({
       message: 'Error: missing or invalid request body'
     })
   }


### PR DESCRIPTION
Sending POST request with empty body gets the correct error in the response, but app still crashes.
```
curl -X POST http://0.0.0.0:5001/subscribe                  
==>                  
{"message":"Error: missing or invalid request body"}% 
```
```
   reqId: 1
    req: {
      "method": "POST",
      "url": "/subscribe",
      "hostname": "0.0.0.0:5001",
      "remoteAddress": "127.0.0.1",
      "remotePort": 60804
    }
/work/node-walletconnect-bridge/build/index.js:96
      topic = _req$body.topic,
                        ^

TypeError: Cannot read property 'topic' of null
```

Adding return prevents the crash